### PR TITLE
feat: add stream support for consumers

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -12,7 +12,7 @@ export interface Connection {
   createPublisher(options?: DestinationOptions): Promise<Publisher>
   get publishers(): Map<string, Publisher>
   get consumers(): Map<string, Consumer>
-  createConsumer(queueName: string, params: CreateConsumerParams): Promise<Consumer>
+  createConsumer(params: CreateConsumerParams): Promise<Consumer>
 }
 
 export class AmqpConnection implements Connection {
@@ -59,8 +59,8 @@ export class AmqpConnection implements Connection {
     })
   }
 
-  async createConsumer(queueName: string, params: CreateConsumerParams): Promise<Consumer> {
-    const consumer = await AmqpConsumer.createFrom(this.connection, this._consumers, queueName, params)
+  async createConsumer(params: CreateConsumerParams): Promise<Consumer> {
+    const consumer = await AmqpConsumer.createFrom(this.connection, this._consumers, params)
     this._consumers.set(consumer.id, consumer)
     return consumer
   }

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,6 +1,7 @@
 import { generate_uuid, MessageAnnotations, Message as RheaMessage } from "rhea"
 import { AmqpEndpoints } from "./link_message_builder.js"
 import { inspect } from "util"
+import { CreateConsumerParams } from "./consumer.js"
 
 export type ExchangeOptions = {
   name: string
@@ -24,21 +25,16 @@ export function createAmqpMessage(options: MessageOptions): RheaMessage {
     return {
       message_id: generate_uuid(),
       body: options.body,
-      to: createAddressFrom(options.destination),
+      to: createPublisherAddressFrom(options.destination),
       durable: true,
-      message_annotations: options.annotations ?? {},
+      message_annotations: options.annotations,
     }
   }
 
-  return {
-    message_id: generate_uuid(),
-    body: options.body,
-    durable: true,
-    message_annotations: options.annotations ?? {},
-  }
+  return { message_id: generate_uuid(), body: options.body, durable: true, message_annotations: options.annotations }
 }
 
-export function createAddressFrom(options?: DestinationOptions): string | undefined {
+export function createPublisherAddressFrom(options?: DestinationOptions): string | undefined {
   if (!options) return undefined
   if ("queue" in options) return `/${AmqpEndpoints.Queues}/${options.queue.name}`
   if ("exchange" in options) {
@@ -48,4 +44,11 @@ export function createAddressFrom(options?: DestinationOptions): string | undefi
   }
 
   throw new Error(`Unknown publisher options -- ${inspect(options)}`)
+}
+
+export function createConsumerAddressFrom(params: CreateConsumerParams): string | undefined {
+  if ("queue" in params) return `/${AmqpEndpoints.Queues}/${params.queue.name}`
+  if ("stream" in params) return `/${AmqpEndpoints.Queues}/${params.stream.name}`
+
+  throw new Error(`Unknown publisher options -- ${inspect(params)}`)
 }

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -2,7 +2,7 @@ import { Connection, Delivery, EventContext, Message, ReceiverOptions, Sender, S
 import { openLink, OutcomeState } from "./utils.js"
 import { randomUUID } from "crypto"
 import { inspect } from "util"
-import { createAddressFrom, DestinationOptions } from "./message.js"
+import { createPublisherAddressFrom, DestinationOptions } from "./message.js"
 
 const getPublisherSenderLinkConfigurationFrom = (
   publisherId: string,
@@ -47,7 +47,7 @@ export class AmqpPublisher implements Publisher {
     publishersList: Map<string, Publisher>,
     options?: DestinationOptions
   ): Promise<Publisher> {
-    const address = createAddressFrom(options)
+    const address = createPublisherAddressFrom(options)
     const id = randomUUID()
     const senderLink = await AmqpPublisher.openSender(connection, id, address)
     return new AmqpPublisher(connection, senderLink, id, publishersList)

--- a/test/e2e/connection.test.ts
+++ b/test/e2e/connection.test.ts
@@ -108,7 +108,8 @@ describe("Connection", () => {
   })
 
   test("create a consumer linked to a queue", async () => {
-    await connection.createConsumer(queueName, {
+    await connection.createConsumer({
+      queue: { name: queueName },
       messageHandler: async (msg) => {
         console.log(msg)
       },
@@ -118,7 +119,8 @@ describe("Connection", () => {
   })
 
   test("close a consumer", async () => {
-    const consumer = await connection.createConsumer(queueName, {
+    const consumer = await connection.createConsumer({
+      queue: { name: queueName },
       messageHandler: async (msg) => {
         console.log(msg)
       },
@@ -131,7 +133,8 @@ describe("Connection", () => {
 
   test("closing the connection also closes the consumer", async () => {
     const newConnection = await environment.createConnection()
-    await newConnection.createConsumer(queueName, {
+    await newConnection.createConsumer({
+      queue: { name: queueName },
       messageHandler: async (msg) => {
         console.log(msg)
       },


### PR DESCRIPTION
This PR adds stream support for consumer, the consumer now can be declared as such:

```typescript
const consumer = await connection.createConsumer({ 
  stream: { 
       name: "some-stream",       // mandatory
       offset: Offset.first(),            // optional
       filterValues: ["invoices", "orders"],  //optional
       matchUnfiltered: true         // optional
  },
  messageHandler: (context, msg) => /* ... */ })
```
We also added support for filterValues.
Note that if both `offset` and `filterValues` are not defined the client will throw an error, since to use message filtering at least one parameter is needed.