### PR TITLE
fix: add websocket url option and fix example

### DIFF
--- a/examples/websocket_example.js
+++ b/examples/websocket_example.js
@@ -1,10 +1,10 @@
 const rabbit = require("rabbitmq-amqp-js-client")
 const { randomUUID } = require("crypto")
 
-const rabbitUser = process.env.RABBITMQ_USER ?? "rabbit"
-const rabbitPassword = process.env.RABBITMQ_PASSWORD ?? "rabbit"
+const rabbitUser = process.env.RABBITMQ_USER ?? "guest"
+const rabbitPassword = process.env.RABBITMQ_PASSWORD ?? "guest"
 const rabbitHost = process.env.RABBITMQ_HOSTNAME ?? "localhost"
-const rabbitPort = process.env.RABBITMQ_PORT ?? 5672
+const rabbitPort = process.env.RABBITMQ_PORT ?? 15678
 
 async function main() {
   const testExchange = `test-exchange-${randomUUID()}`

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -107,11 +107,9 @@ function buildConnectParams(envParams: EnvironmentParams, connParams?: Connectio
   const reconnectParams = buildReconnectParams(connParams)
   if (envParams.webSocket) {
     const ws = websocket_connect(envParams.webSocket)
-    const connectionDetails = ws(
-      `ws://${envParams.username}:${envParams.password}@${envParams.host}:${envParams.port}`,
-      "amqp",
-      {}
-    )
+    const wsUrl = envParams.webSocketUrl ?? `ws://${envParams.host}:${envParams.port}/ws`
+    const connectionDetails = ws(wsUrl, "amqp", {})
+
     return {
       connection_details: () => {
         return {
@@ -120,9 +118,8 @@ function buildConnectParams(envParams: EnvironmentParams, connParams?: Connectio
           port: envParams.port,
         }
       },
-      host: envParams.host,
-      port: envParams.port,
-      transport: "tcp",
+      ...envParams,
+      ...reconnectParams,
     }
   }
 

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -12,6 +12,7 @@ export type EnvironmentParams = {
   username: string
   password: string
   webSocket?: WebSocketImpl
+  webSocketUrl?: string
 }
 
 export class AmqpEnvironment implements Environment {


### PR DESCRIPTION
In this PR we add an option to specify the websocket url directly and we fix the `websocket_example.js`

```typescript
const environment = rabbit.createEnvironment({
    host: rabbitHost,
    port: rabbitPort,
    username: rabbitUser,
    password: rabbitPassword,
    webSocket: WebSocket,
    webSocketUrl: "ws://localhost:15678/ws"
  })
```