### PR TITLE
[feat/IS-45]: reconnect to rabbit through oauth2.0

### DIFF
--- a/conf/advanced.config
+++ b/conf/advanced.config
@@ -1,0 +1,13 @@
+[
+  {rabbitmq_auth_backend_oauth2, [{key_config,
+         [{signing_keys,
+              #{<<"token-key">> =>
+                    {map,
+                        #{<<"alg">> => <<"HS256">>,
+                          <<"k">> => <<"abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH">>,
+                          <<"kid">> => <<"token-key">>,
+                          <<"kty">> => <<"oct">>,
+                          <<"use">> => <<"sig">>,
+                          <<"value">> => <<"token-key">>}}}}]},
+     {resource_server_id,<<"rabbitmq">>}]}
+].

--- a/conf/enabled_plugins
+++ b/conf/enabled_plugins
@@ -1,1 +1,1 @@
-[rabbit_stream,rabbitmq_stream_management,rabbitmq_management,rabbitmq_top,rabbitmq_consistent_hash_exchange].
+[rabbit_stream,rabbitmq_stream_management,rabbitmq_management,rabbitmq_top,rabbitmq_consistent_hash_exchange,rabbitmq_auth_backend_oauth2].

--- a/conf/rabbitmq.conf
+++ b/conf/rabbitmq.conf
@@ -8,3 +8,10 @@ log.exchange = true
 listeners.tcp.default = 5672
 
 deprecated_features.permit.amqp_address_v1 = false
+
+auth_mechanisms.1 = PLAIN
+auth_mechanisms.2 = ANONYMOUS
+auth_mechanisms.3 = EXTERNAL
+
+auth_backends.1 = internal
+auth_backends.2 = rabbit_auth_backend_oauth2

--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
     "dste",
     "dstq",
     "fanout",
+    "keyid",
     "perftest",
     "prefetch",
     "RABBITMQ",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,13 @@
       "devDependencies": {
         "@eslint/js": "^9.28.0",
         "@tsconfig/node22": "^22.0.2",
+        "@types/jsonwebtoken": "^9.0.10",
         "assertion-error": "^2.0.1",
         "cspell": "^8.19.4",
         "eslint": "^9.28.0",
         "globals": "^16.2.0",
         "got": "^14.4.7",
+        "jsonwebtoken": "^9.0.2",
         "prettier": "3.5.3",
         "tsup": "^8.5.0",
         "typescript": "^5.8.3",
@@ -1228,14 +1230,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1785,14 +1800,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.15.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
       "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2271,6 +2302,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
@@ -2822,6 +2860,16 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -3716,6 +3764,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3786,10 +3880,59 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4451,6 +4594,27 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -4959,9 +5123,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -49,11 +49,13 @@
   "devDependencies": {
     "@eslint/js": "^9.28.0",
     "@tsconfig/node22": "^22.0.2",
+    "@types/jsonwebtoken": "^9.0.10",
     "assertion-error": "^2.0.1",
     "cspell": "^8.19.4",
     "eslint": "^9.28.0",
     "globals": "^16.2.0",
     "got": "^14.4.7",
+    "jsonwebtoken": "^9.0.2",
     "prettier": "3.5.3",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,15 +1,10 @@
-import {
-  ConnectionEvents,
-  ConnectionOptions,
-  create_container,
-  Connection as RheaConnection,
-  websocket_connect,
-} from "rhea"
+import { ConnectionEvents, Connection as RheaConnection } from "rhea"
 import { AmqpManagement, Management } from "./management.js"
 import { EnvironmentParams } from "./environment.js"
 import { AmqpPublisher, Publisher } from "./publisher.js"
 import { DestinationOptions } from "./message.js"
 import { AmqpConsumer, Consumer, CreateConsumerParams } from "./consumer.js"
+import { openRheaConnection } from "./rhea_wrapper.js"
 
 export interface Connection {
   close(): Promise<boolean>
@@ -19,6 +14,7 @@ export interface Connection {
   get publishers(): Map<string, Publisher>
   get consumers(): Map<string, Consumer>
   createConsumer(params: CreateConsumerParams): Promise<Consumer>
+  refreshToken: (token: string) => Promise<boolean>
 }
 
 export type ConnectionParams =
@@ -30,34 +26,50 @@ export type ConnectionParams =
       reconnectLimit?: number
     }
 
+class PasswordSettings {
+  private func: (() => string) | null = null
+
+  register(func: () => string) {
+    this.func = func
+  }
+
+  getPassword(): string {
+    return this.func ? this.func() : ""
+  }
+}
+
 export class AmqpConnection implements Connection {
   private _publishers: Map<string, Publisher> = new Map<string, Publisher>()
   private _consumers: Map<string, Consumer> = new Map<string, Consumer>()
 
   static async create(envParams: EnvironmentParams, connParams?: ConnectionParams) {
-    const connection = await AmqpConnection.open(envParams, connParams)
-    const topologyManagement = await AmqpManagement.create(connection)
-    return new AmqpConnection(connection, topologyManagement)
-  }
+    const settings = new PasswordSettings()
 
-  private static async open(envParams: EnvironmentParams, connParams?: ConnectionParams): Promise<RheaConnection> {
-    return new Promise((res, rej) => {
-      const container = create_container()
-      container.once(ConnectionEvents.connectionOpen, (context) => {
-        return res(context.connection)
-      })
-      container.once(ConnectionEvents.error, (context) => {
-        return rej(context.error ?? new Error("Connection error occurred"))
-      })
+    if (envParams.token) {
+      const rheaOauthConnection = await openRheaConnection(envParams, connParams, () => settings.getPassword())
+      const topologyManagement = await AmqpManagement.create(rheaOauthConnection)
+      console.log("TOKEN", envParams.token)
+      return new AmqpConnection(rheaOauthConnection, topologyManagement, settings, envParams.token)
+    }
 
-      container.connect(buildConnectParams(envParams, connParams))
-    })
+    const rheaPlainConnection = await openRheaConnection(envParams, connParams)
+    const topologyManagement = await AmqpManagement.create(rheaPlainConnection)
+    return new AmqpConnection(rheaPlainConnection, topologyManagement, settings, envParams.password!)
   }
 
   constructor(
     private readonly connection: RheaConnection,
-    private readonly topologyManagement: Management
-  ) {}
+    private readonly topologyManagement: Management,
+    private readonly settings: PasswordSettings,
+    private password: string
+  ) {
+    settings.register(() => this.getPassword())
+  }
+
+  private getPassword() {
+    console.log("CALLED")
+    return this.password
+  }
 
   async close(): Promise<boolean> {
     return new Promise((res, rej) => {
@@ -90,6 +102,15 @@ export class AmqpConnection implements Connection {
     return publisher
   }
 
+  async refreshToken(token: string): Promise<boolean> {
+    const ok = await this.topologyManagement.refreshToken(token)
+
+    if (!ok) return false
+
+    this.password = token
+    return true
+  }
+
   public get publishers(): Map<string, Publisher> {
     return this._publishers
   }
@@ -101,45 +122,4 @@ export class AmqpConnection implements Connection {
   public isOpen(): boolean {
     return this.connection ? this.connection.is_open() : false
   }
-}
-
-function buildConnectParams(envParams: EnvironmentParams, connParams?: ConnectionParams): ConnectionOptions {
-  const reconnectParams = buildReconnectParams(connParams)
-  if (envParams.webSocket) {
-    const ws = websocket_connect(envParams.webSocket)
-    const wsUrl = envParams.webSocketUrl ?? `ws://${envParams.host}:${envParams.port}/ws`
-    const connectionDetails = ws(wsUrl, "amqp", {})
-
-    return {
-      connection_details: () => {
-        return {
-          ...connectionDetails(),
-          host: envParams.host,
-          port: envParams.port,
-        }
-      },
-      ...envParams,
-      ...reconnectParams,
-    }
-  }
-
-  return {
-    ...envParams,
-    ...reconnectParams,
-  }
-}
-
-function buildReconnectParams(connParams?: ConnectionParams) {
-  if (connParams && connParams.reconnect) {
-    return {
-      reconnect: connParams.reconnect,
-      initial_reconnect_delay: connParams.initialReconnectDelay,
-      max_reconnect_delay: connParams.maxReconnectDelay,
-      reconnect_limit: connParams.reconnectLimit,
-    }
-  }
-
-  if (connParams && !connParams.reconnect) return { reconnect: false }
-
-  return { reconnect: true }
 }

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -11,12 +11,12 @@ import {
 } from "rhea"
 import {
   Offset,
-  openLink,
   SourceFilter,
   STREAM_FILTER_MATCH_UNFILTERED,
   STREAM_FILTER_SPEC,
   STREAM_OFFSET_SPEC,
 } from "./utils.js"
+import { openLink } from "./rhea_wrapper.js"
 import { createConsumerAddressFrom } from "./message.js"
 import { QueueOptions } from "./message.js"
 import { AmqpDeliveryContext, DeliveryContext } from "./delivery_context.js"

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -6,14 +6,27 @@ export interface Environment {
   close(): Promise<void>
 }
 
-export type EnvironmentParams = {
+type EnvironmentParamsWithPassword = {
   host: string
   port: number
   username: string
   password: string
+  token?: never
   webSocket?: WebSocketImpl
   webSocketUrl?: string
 }
+
+type EnvironmentParamsWithToken = {
+  host: string
+  port: number
+  username: string
+  token: string
+  password?: never
+  webSocket?: WebSocketImpl
+  webSocketUrl?: string
+}
+
+export type EnvironmentParams = EnvironmentParamsWithPassword | EnvironmentParamsWithToken
 
 export class AmqpEnvironment implements Environment {
   constructor(

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -6,27 +6,23 @@ export interface Environment {
   close(): Promise<void>
 }
 
-type EnvironmentParamsWithPassword = {
+type WebSocketParams = {
+  implementation: WebSocketImpl
+  url?: string
+}
+
+type OauthParams = {
+  token: string
+}
+
+export type EnvironmentParams = {
   host: string
   port: number
   username: string
   password: string
-  token?: never
-  webSocket?: WebSocketImpl
-  webSocketUrl?: string
+  webSocket?: WebSocketParams
+  oauth?: OauthParams
 }
-
-type EnvironmentParamsWithToken = {
-  host: string
-  port: number
-  username: string
-  token: string
-  password?: never
-  webSocket?: WebSocketImpl
-  webSocketUrl?: string
-}
-
-export type EnvironmentParams = EnvironmentParamsWithPassword | EnvironmentParamsWithToken
 
 export class AmqpEnvironment implements Environment {
   constructor(

--- a/src/link_message_builder.ts
+++ b/src/link_message_builder.ts
@@ -8,6 +8,7 @@ export enum AmqpMethods {
 }
 
 export enum AmqpEndpoints {
+  AuthTokens = "auth/tokens",
   Queues = "queues",
   Exchanges = "exchanges",
   Bindings = "bindings",

--- a/src/management.ts
+++ b/src/management.ts
@@ -34,7 +34,6 @@ export const MANAGEMENT_NODE_CONFIGURATION: SenderOptions | ReceiverOptions = {
 }
 
 export interface Management {
-  refreshToken(token: string): Promise<boolean>
   declareQueue: (queueName: string, options?: Partial<QueueOptions>) => Promise<Queue>
   deleteQueue: (queueName: string) => Promise<boolean>
   getQueueInfo: (queueName: string) => Promise<Queue>

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -1,5 +1,6 @@
 import { Connection, Delivery, EventContext, Message, ReceiverOptions, Sender, SenderEvents, SenderOptions } from "rhea"
-import { openLink, OutcomeState } from "./utils.js"
+import { OutcomeState } from "./utils.js"
+import { openLink } from "./rhea_wrapper.js"
 import { randomUUID } from "crypto"
 import { inspect } from "util"
 import { createPublisherAddressFrom, DestinationOptions } from "./message.js"

--- a/src/response_decoder.ts
+++ b/src/response_decoder.ts
@@ -71,3 +71,5 @@ export class DeleteExchangeResponseDecoder extends EmptyBodyResponseDecoder {}
 export class CreateBindingResponseDecoder extends EmptyBodyResponseDecoder {}
 
 export class DeleteBindingResponseDecoder extends EmptyBodyResponseDecoder {}
+
+export class RefreshTokensResponseDecoder extends EmptyBodyResponseDecoder {}

--- a/src/rhea_wrapper.ts
+++ b/src/rhea_wrapper.ts
@@ -1,0 +1,117 @@
+import {
+  ConnectionEvents,
+  ConnectionOptions,
+  create_container,
+  Receiver,
+  ReceiverEvents,
+  Connection as RheaConnection,
+  Sender,
+  SenderEvents,
+  websocket_connect,
+} from "rhea"
+import { MANAGEMENT_NODE_CONFIGURATION } from "./management.js"
+import { openLink } from "./utils.js"
+import { ConnectionParams } from "./connection.js"
+import { EnvironmentParams } from "./environment.js"
+
+export async function openRheaConnection(
+  envParams: EnvironmentParams,
+  connParams?: ConnectionParams,
+  getOauthPassword?: () => string
+): Promise<RheaConnection> {
+  return new Promise((res, rej) => {
+    const container = create_container()
+    container.once(ConnectionEvents.connectionOpen, (context) => {
+      return res(context.connection)
+    })
+    container.once(ConnectionEvents.connectionError, (context) => {
+      return rej(context.error ?? new Error("Connection error occurred"))
+    })
+
+    container.connect(buildConnectParams(envParams, connParams, getOauthPassword))
+  })
+}
+
+export async function openSender(connection: RheaConnection): Promise<Sender> {
+  return openLink<Sender>(
+    connection,
+    SenderEvents.senderOpen,
+    SenderEvents.senderError,
+    connection.open_sender.bind(connection),
+    MANAGEMENT_NODE_CONFIGURATION
+  )
+}
+
+export async function openReceiver(connection: RheaConnection): Promise<Receiver> {
+  return openLink<Receiver>(
+    connection,
+    ReceiverEvents.receiverOpen,
+    ReceiverEvents.receiverError,
+    connection.open_receiver.bind(connection),
+    MANAGEMENT_NODE_CONFIGURATION
+  )
+}
+
+function buildConnectParams(
+  envParams: EnvironmentParams,
+  connParams?: ConnectionParams,
+  getOauthPassword?: () => string
+): ConnectionOptions {
+  const reconnectParams = buildReconnectParams(connParams)
+  if (envParams.webSocket) {
+    const ws = websocket_connect(envParams.webSocket)
+    const wsUrl = envParams.webSocketUrl ?? `ws://${envParams.host}:${envParams.port}/ws`
+    const connectionDetails = ws(wsUrl, "amqp", {})
+
+    return {
+      connection_details: () => {
+        return {
+          ...connectionDetails(),
+          host: envParams.host,
+          port: envParams.port,
+        }
+      },
+      ...envParams,
+      ...reconnectParams,
+    }
+  }
+
+  if (envParams.token) {
+    return {
+      connection_details: () => {
+        return {
+          host: envParams.host,
+          port: envParams.port,
+          username: envParams.username,
+          password: getOauthPassword ? getOauthPassword() : undefined,
+          ...reconnectParams,
+        }
+      },
+      host: envParams.host,
+      port: envParams.port,
+      username: envParams.username,
+      password: envParams.token,
+      ...reconnectParams,
+    }
+  }
+
+  return {
+    ...envParams,
+    ...reconnectParams,
+  }
+}
+
+function buildReconnectParams(connParams?: ConnectionParams) {
+  if (connParams && connParams.reconnect) {
+    return {
+      reconnect: connParams.reconnect,
+      initial_reconnect_delay: connParams.initialReconnectDelay,
+      max_reconnect_delay: connParams.maxReconnectDelay,
+      reconnect_limit: connParams.reconnectLimit,
+    }
+  }
+
+  if (connParams && !connParams.reconnect) return { reconnect: false }
+
+  return { reconnect: true }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,14 +1,4 @@
-import {
-  Connection,
-  Dictionary,
-  Message,
-  Receiver,
-  ReceiverEvents,
-  ReceiverOptions,
-  Sender,
-  SenderEvents,
-  SenderOptions,
-} from "rhea"
+import { Dictionary, Message } from "rhea"
 import { QueueType } from "./queue.js"
 
 export enum AmqpResponseCodes {
@@ -67,30 +57,6 @@ export function queueTypeFromString(queueType: string): QueueType {
     default:
       throw new Error(`Unsupported queue type: ${queueType}`)
   }
-}
-
-type LinkOpenEvents = SenderEvents.senderOpen | ReceiverEvents.receiverOpen
-type LinkErrorEvents = SenderEvents.senderError | ReceiverEvents.receiverError
-type OpenLinkMethods =
-  | ((options?: SenderOptions | string) => Sender)
-  | ((options?: ReceiverOptions | string) => Receiver)
-
-export async function openLink<T extends Sender | Receiver>(
-  connection: Connection,
-  successEvent: LinkOpenEvents,
-  errorEvent: LinkErrorEvents,
-  openMethod: OpenLinkMethods,
-  config?: SenderOptions | ReceiverOptions | string
-): Promise<T> {
-  return new Promise((res, rej) => {
-    connection.once(successEvent, (context) => {
-      return res(context.receiver || context.sender)
-    })
-    connection.once(errorEvent, (context) => {
-      return rej(context.connection.error)
-    })
-    openMethod(config)
-  })
 }
 
 export enum OffsetType {

--- a/test/e2e/environment.test.ts
+++ b/test/e2e/environment.test.ts
@@ -52,7 +52,7 @@ describe("Environment", () => {
     await eventually(async () => {
       expect(await numberOfConnections()).to.eql(1)
     })
-  }, 10000)
+  }, 7000)
 
   test("a connection reconnects by default", async () => {
     await environment.createConnection()
@@ -62,7 +62,7 @@ describe("Environment", () => {
     await eventually(async () => {
       expect(await numberOfConnections()).to.eql(1)
     })
-  }, 10000)
+  }, 7000)
 
   test("a connection with reconnect set to number retries after number ms", async () => {
     await environment.createConnection({ reconnect: 2000, initialReconnectDelay: 2000 })

--- a/test/e2e/management.test.ts
+++ b/test/e2e/management.test.ts
@@ -14,6 +14,7 @@ import {
   getExchangeInfo,
   existsBinding,
   cleanRabbit,
+  generateToken,
 } from "../support/util.js"
 import { createEnvironment, Environment } from "../../src/environment.js"
 import { Connection } from "../../src/connection.js"
@@ -48,6 +49,14 @@ describe("Management", () => {
     } catch (error) {
       console.error(error)
     }
+  })
+
+  test("refresh the token through the /auth/tokens endpoint", async () => {
+    const newToken = generateToken(username, 5)
+
+    const result = await management.refreshToken(newToken)
+
+    expect(result).to.eql(true)
   })
 
   describe("queues", async () => {

--- a/test/e2e/oauth_connection.test.ts
+++ b/test/e2e/oauth_connection.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest"
+import { createEnvironment, Environment } from "../../src/environment.js"
+import {
+  host,
+  port,
+  username,
+  generateToken,
+  eventually,
+  numberOfConnections,
+  wait,
+  closeAllConnections,
+} from "../support/util.js"
+import { Connection } from "../../src/connection.js"
+
+describe("Oauth2 Connection", () => {
+  let environment: Environment
+  let connection: Connection
+
+  test("creating an oauth2 connection", async () => {
+    const token = generateToken(username, 10)
+    environment = createEnvironment({ host, port, username, token })
+
+    connection = await environment.createConnection()
+
+    await eventually(async () => {
+      expect(await numberOfConnections()).to.eql(1)
+    })
+    await connection.close()
+    await environment.close()
+  })
+
+  test("refreshing the token of an oauth2 connection", async () => {
+    const token = generateToken(username, 10)
+    environment = createEnvironment({ host, port, username, token })
+
+    connection = await environment.createConnection()
+    await wait(3000)
+    await connection.refreshToken(generateToken(username, 10))
+
+    await eventually(async () => {
+      expect(await numberOfConnections()).to.eql(1)
+    })
+    await connection.close()
+    await environment.close()
+  }, 10000)
+
+  test("reconnect with new token of an oauth2 connection", async () => {
+    const token = generateToken(username, 100)
+    environment = createEnvironment({ host, port, username, token })
+    connection = await environment.createConnection()
+    await connection.refreshToken(generateToken(username, 100))
+
+    await closeAllConnections()
+
+    await eventually(async () => {
+      expect(await numberOfConnections()).to.eql(1)
+    })
+    await connection.close()
+    await environment.close()
+  }, 15000)
+})

--- a/test/e2e/oauth_connection.test.ts
+++ b/test/e2e/oauth_connection.test.ts
@@ -9,6 +9,7 @@ import {
   numberOfConnections,
   wait,
   closeAllConnections,
+  password,
 } from "../support/util.js"
 import { Connection } from "../../src/connection.js"
 
@@ -18,7 +19,7 @@ describe("Oauth2 Connection", () => {
 
   test("creating an oauth2 connection", async () => {
     const token = generateToken(username, 10)
-    environment = createEnvironment({ host, port, username, token })
+    environment = createEnvironment({ host, port, username, password, oauth: { token } })
 
     connection = await environment.createConnection()
 
@@ -31,7 +32,7 @@ describe("Oauth2 Connection", () => {
 
   test("refreshing the token of an oauth2 connection", async () => {
     const token = generateToken(username, 10)
-    environment = createEnvironment({ host, port, username, token })
+    environment = createEnvironment({ host, port, username, password, oauth: { token } })
 
     connection = await environment.createConnection()
     await wait(3000)
@@ -46,7 +47,7 @@ describe("Oauth2 Connection", () => {
 
   test("reconnect with new token of an oauth2 connection", async () => {
     const token = generateToken(username, 100)
-    environment = createEnvironment({ host, port, username, token })
+    environment = createEnvironment({ host, port, username, password, oauth: { token } })
     connection = await environment.createConnection()
     await connection.refreshToken(generateToken(username, 100))
 

--- a/test/unit/rhea/connection.test.ts
+++ b/test/unit/rhea/connection.test.ts
@@ -41,7 +41,7 @@ describe("Rhea connections", () => {
     await eventually(async () => {
       expect(await numberOfConnections()).to.eql(1)
     })
-  })
+  }, 8000)
 
   test.skip("create a connection through a websocket", async () => {
     connection = await openWebSocketConnection(container, `ws://${username}:${password}@${host}:${port}`)

--- a/test/unit/rhea/connection.test.ts
+++ b/test/unit/rhea/connection.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
-import { host, port, username, password, numberOfConnections, eventually } from "../../support/util.js"
+import { host, port, username, password, numberOfConnections, eventually, generateToken } from "../../support/util.js"
 import { Connection, Container, create_container } from "rhea"
 import { closeConnection, openConnection, openManagement, openWebSocketConnection } from "../../support/rhea_utils.js"
 
@@ -21,6 +21,21 @@ describe("Rhea connections", () => {
       port,
       username,
       password,
+    })
+
+    await eventually(async () => {
+      expect(await numberOfConnections()).to.eql(1)
+    })
+  })
+
+  test("create a connection using oauth2", async () => {
+    const token = generateToken(username, 60)
+
+    connection = await openConnection(container, {
+      host,
+      port,
+      username,
+      password: token,
     })
 
     await eventually(async () => {


### PR DESCRIPTION
In this PR we add the possibility to connect to rabbitmq through oauth2.0 plain.

Usage example:
```typescript
const environment = createEnvironment({ 
 host, 
 port, 
 username,
 password: "",
 oauth: {
     token: "<my-token>"
}
```

We also add the possibility to refresh the token for the connection

```typescript
await connection.refreshToken("new-token-value")
```