### PR TITLE
[feat/IS-70] support filter expressions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       rabbitmq:
-        image: rabbitmq:4.1.1-management
+        image: rabbitmq:4.2.0-beta.3-management
         options: --hostname test-node --name test-node
         env:
           RABBITMQ_HOSTNAME: "test-node"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   rabbitmq-js-client:
-    image: rabbitmq:4.1.1-management
+    image: rabbitmq:4.2.0-beta.3-management
     container_name: rabbitmq-js-client
     restart: unless-stopped
     hostname: "rabbitmq"

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -8,6 +8,7 @@ import {
   EventContext,
   Message,
   Dictionary,
+  filter,
 } from "rhea"
 import {
   Offset,
@@ -53,10 +54,7 @@ const getConsumerReceiverLinkConfigurationFrom = (
     timeout: 0,
     dynamic: false,
     durable: 0,
-    filter: {
-      selector: (s: string) => filter ? filter[s] : undefined,
-      ...filter
-    },
+    filter,
   },
 })
 
@@ -130,7 +128,7 @@ function createConsumerFilterFrom(params: CreateConsumerParams): SourceFilter | 
     throw new Error("At least one between offset and filterValues must be set when using filtering")
   }
 
-  const filters: Dictionary<string | bigint | boolean | string[]> = {}
+  const filters: Dictionary<string | bigint | boolean | string[] | any> = {}
   if (params.stream.offset) {
     filters[STREAM_OFFSET_SPEC] = params.stream.offset.toValue()
   }
@@ -138,7 +136,9 @@ function createConsumerFilterFrom(params: CreateConsumerParams): SourceFilter | 
     filters[STREAM_FILTER_SPEC] = params.stream.filterValues
   }
   if (params.stream.sqlFilter) {
-    filters[STREAM_SQL_FILTER] = params.stream.sqlFilter
+    console.log(filter.selector(`Described(${String(Symbol("amqp:sql-filter"))}, ${params.stream.sqlFilter})`))
+    const { descriptor, value } = filter.selector(params.stream.sqlFilter)["jms-selector"]
+    filters["sql-filter"] = { descriptor: descriptor.value, value }
   }
   if (params.stream.matchUnfiltered) {
     filters[STREAM_FILTER_MATCH_UNFILTERED] = params.stream.matchUnfiltered

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -15,6 +15,7 @@ import {
   STREAM_FILTER_MATCH_UNFILTERED,
   STREAM_FILTER_SPEC,
   STREAM_OFFSET_SPEC,
+  STREAM_SQL_FILTER,
 } from "./utils.js"
 import { openLink } from "./rhea_wrapper.js"
 import { createConsumerAddressFrom } from "./message.js"
@@ -27,6 +28,7 @@ export type StreamOptions = {
   name: string
   offset?: Offset
   filterValues?: string[]
+  sqlFilter?: string
   matchUnfiltered?: boolean
 }
 
@@ -51,7 +53,10 @@ const getConsumerReceiverLinkConfigurationFrom = (
     timeout: 0,
     dynamic: false,
     durable: 0,
-    filter,
+    filter: {
+      selector: (s: string) => filter ? filter[s] : undefined,
+      ...filter
+    },
   },
 })
 
@@ -131,6 +136,9 @@ function createConsumerFilterFrom(params: CreateConsumerParams): SourceFilter | 
   }
   if (params.stream.filterValues) {
     filters[STREAM_FILTER_SPEC] = params.stream.filterValues
+  }
+  if (params.stream.sqlFilter) {
+    filters[STREAM_SQL_FILTER] = params.stream.sqlFilter
   }
   if (params.stream.matchUnfiltered) {
     filters[STREAM_FILTER_MATCH_UNFILTERED] = params.stream.matchUnfiltered

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,4 +1,4 @@
-import { generate_uuid, MessageAnnotations, Message as RheaMessage } from "rhea"
+import { generate_uuid, MessageAnnotations, MessageProperties, Message as RheaMessage } from "rhea"
 import { AmqpEndpoints } from "./link_message_builder.js"
 import { inspect } from "util"
 import { CreateConsumerParams } from "./consumer.js"
@@ -18,6 +18,7 @@ type MessageOptions = {
   body: string
   destination?: DestinationOptions
   annotations?: MessageAnnotations
+  properties?: MessageProperties
 }
 
 export function createAmqpMessage(options: MessageOptions): RheaMessage {
@@ -28,10 +29,11 @@ export function createAmqpMessage(options: MessageOptions): RheaMessage {
       to: createPublisherAddressFrom(options.destination),
       durable: true,
       message_annotations: options.annotations,
+      application_properties: options.properties,
     }
   }
 
-  return { message_id: generate_uuid(), body: options.body, durable: true, message_annotations: options.annotations }
+  return { message_id: generate_uuid(), body: options.body, durable: true, message_annotations: options.annotations, application_properties: options.properties, }
 }
 
 export function createPublisherAddressFrom(options?: DestinationOptions): string | undefined {

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,4 +1,4 @@
-import { generate_uuid, MessageAnnotations, MessageProperties, Message as RheaMessage } from "rhea"
+import { Dictionary, generate_uuid, MessageAnnotations, MessageProperties, Message as RheaMessage } from "rhea"
 import { AmqpEndpoints } from "./link_message_builder.js"
 import { inspect } from "util"
 import { CreateConsumerParams } from "./consumer.js"
@@ -18,7 +18,8 @@ type MessageOptions = {
   body: string
   destination?: DestinationOptions
   annotations?: MessageAnnotations
-  properties?: MessageProperties
+  message_properties?: MessageProperties
+  application_properties?: Dictionary<string>
 }
 
 export function createAmqpMessage(options: MessageOptions): RheaMessage {
@@ -29,11 +30,19 @@ export function createAmqpMessage(options: MessageOptions): RheaMessage {
       to: createPublisherAddressFrom(options.destination),
       durable: true,
       message_annotations: options.annotations,
-      application_properties: options.properties,
+      application_properties: options.application_properties,
+      ...(options.message_properties ? options.message_properties : {}),
     }
   }
 
-  return { message_id: generate_uuid(), body: options.body, durable: true, message_annotations: options.annotations, application_properties: options.properties, }
+  return {
+    message_id: generate_uuid(),
+    body: options.body,
+    durable: true,
+    message_annotations: options.annotations,
+    application_properties: options.application_properties,
+    ...(options.message_properties ? options.message_properties : {}),
+  }
 }
 
 export function createPublisherAddressFrom(options?: DestinationOptions): string | undefined {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Dictionary, Message } from "rhea"
+import { Dictionary, Message, Typed } from "rhea"
 import { QueueType } from "./queue.js"
 
 export enum AmqpResponseCodes {
@@ -20,12 +20,14 @@ export const DURABLE = 1
 export const AUTO_DELETE = 1
 export const EXCLUSIVE = 1
 
-export const STREAM_FILTER_SPEC = "rabbitmq:stream-filter"
 export const STREAM_OFFSET_SPEC = "rabbitmq:stream-offset-spec"
+export const STREAM_FILTER_SPEC = "rabbitmq:stream-filter"
 export const STREAM_FILTER_MATCH_UNFILTERED = "rabbitmq:stream-match-unfiltered"
-export const STREAM_SQL_FILTER = "amqp:sql-filter"
+export const STREAM_FILTER_MESSAGE_PROPERTIES = "properties-filter"
+export const STREAM_FILTER_APPLICATION_PROPERTIES = "application-properties-filter"
+export const STREAM_FILTER_SQL = "sql-filter"
 
-export type SourceFilter = Dictionary<string | bigint | boolean | string[]>
+export type SourceFilter = Dictionary<string | bigint | boolean | string[] | Typed>
 
 export type Result<T, K> = OkResult<T> | ErrorResult<K>
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,6 +23,7 @@ export const EXCLUSIVE = 1
 export const STREAM_FILTER_SPEC = "rabbitmq:stream-filter"
 export const STREAM_OFFSET_SPEC = "rabbitmq:stream-offset-spec"
 export const STREAM_FILTER_MATCH_UNFILTERED = "rabbitmq:stream-match-unfiltered"
+export const STREAM_SQL_FILTER = "amqp:sql-filter"
 
 export type SourceFilter = Dictionary<string | bigint | boolean | string[]>
 

--- a/test/e2e/consumer.test.ts
+++ b/test/e2e/consumer.test.ts
@@ -202,21 +202,19 @@ describe("Consumer", () => {
     })
   })
 
-
-
   test("consumer can handle message on stream with sql filters", async () => {
     const publisher = await connection.createPublisher({ queue: { name: streamName } })
     const filteredMessage = createAmqpMessage({
       body: "my body",
-      properties: {
-        subject: "foo"
-      }
+      message_properties: {
+        subject: "foo",
+      },
     })
     const discardedMessage = createAmqpMessage({
       body: "discard me",
-      properties: {
-        subject: "bar"
-      }
+      message_properties: {
+        subject: "bar",
+      },
     })
     await publisher.publish(filteredMessage)
     await publisher.publish(discardedMessage)
@@ -230,12 +228,9 @@ describe("Consumer", () => {
         sqlFilter: "properties.subject = '123'",
       },
       messageHandler: (context, message) => {
-        console.log("message", message.application_properties)
-        if (
-          message.application_properties
-          && message.application_properties.subject == "foo"
-        ) {
-          console.log("sono qui ")
+        console.log("message", message.subject)
+        if (message.subject && message.subject == "foo") {
+          console.log("hello ")
           received = message.body
         }
         context.accept()

--- a/test/e2e/consumer.test.ts
+++ b/test/e2e/consumer.test.ts
@@ -202,6 +202,52 @@ describe("Consumer", () => {
     })
   })
 
+
+
+  test("consumer can handle message on stream with sql filters", async () => {
+    const publisher = await connection.createPublisher({ queue: { name: streamName } })
+    const filteredMessage = createAmqpMessage({
+      body: "my body",
+      properties: {
+        subject: "foo"
+      }
+    })
+    const discardedMessage = createAmqpMessage({
+      body: "discard me",
+      properties: {
+        subject: "bar"
+      }
+    })
+    await publisher.publish(filteredMessage)
+    await publisher.publish(discardedMessage)
+    let received: string = ""
+
+    const consumer = await connection.createConsumer({
+      stream: {
+        name: streamName,
+        offset: Offset.first(),
+        matchUnfiltered: false,
+        sqlFilter: "properties.subject = '123'",
+      },
+      messageHandler: (context, message) => {
+        console.log("message", message.application_properties)
+        if (
+          message.application_properties
+          && message.application_properties.subject == "foo"
+        ) {
+          console.log("sono qui ")
+          received = message.body
+        }
+        context.accept()
+      },
+    })
+    consumer.start()
+
+    await eventually(() => {
+      expect(received).to.be.eql("my body")
+    })
+  })
+
   test("consumer can discard a message published to a queue", async () => {
     const publisher = await connection.createPublisher({ queue: { name: discardQueueName } })
     const expectedBody = "ciao"


### PR DESCRIPTION
Add filtering options in stream:
- Sql Filters
- Properties Filters
- Application Properties Filters

Example: 
```typescript
    const consumer = await connection.createConsumer({
      stream: {
        name: streamName,
        offset: Offset.first(),
        matchUnfiltered: false,
        messagePropertiesFilter: { subject: "foo" },
        sqlFilter: "p.subject = 'foo'",
        applicationPropertiesFilter: { test: "foo"},
      },
      messageHandler: (context) => { ... },
    })
```