### PR TITLE
Eliminate race condition in management listener.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1342,63 +1342,12 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.52.13",
@@ -3175,15 +3124,6 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -6730,19 +6670,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6862,36 +6789,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/terser": {
-      "version": "5.44.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
-      "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.15.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/timers-browserify": {
       "version": "2.0.12",

--- a/src/management.ts
+++ b/src/management.ts
@@ -2,6 +2,7 @@ import { AmqpExchange, Exchange, ExchangeInfo, ExchangeOptions } from "./exchang
 import { AmqpQueue, Queue, QueueType, QueueOptions, QuorumQueueOptions, ClassicQueueOptions } from "./queue.js"
 import {
   EventContext,
+  Message,
   Receiver,
   ReceiverEvents,
   ReceiverOptions,
@@ -54,11 +55,37 @@ export class AmqpManagement implements Management {
     return new AmqpManagement(connection, senderLink, receiverLink)
   }
 
+  private readonly pendingRequests = new Map<
+    string,
+    { resolve: (msg: Message) => void; reject: (err: Error) => void }
+  >()
+
   constructor(
     private readonly connection: RheaConnection,
     private senderLink: Sender,
     private receiverLink: Receiver
-  ) {}
+  ) {
+    this.startResponseRouter()
+  }
+
+  private startResponseRouter(): void {
+    this.receiverLink.on(ReceiverEvents.message, (context: EventContext) => {
+      if (!context.message) return
+      const correlationId = String(context.message.correlation_id)
+      const pending = this.pendingRequests.get(correlationId)
+      if (pending) {
+        this.pendingRequests.delete(correlationId)
+        pending.resolve(context.message)
+      }
+    })
+  }
+
+  private sendAndAwait(message: Message): Promise<Message> {
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(String(message.message_id), { resolve, reject })
+      this.senderLink.send(message)
+    })
+  }
 
   close(): void {
     if (this.connection.is_closed()) return
@@ -76,76 +103,40 @@ export class AmqpManagement implements Management {
   }
 
   async declareQueue(queueName: string, options: Partial<QueueOptions> = {}): Promise<Queue> {
-    return new Promise((res, rej) => {
-      this.receiverLink.once(ReceiverEvents.message, (context: EventContext) => {
-        if (!context.message) {
-          return rej(new Error("Receiver has not received any message"))
-        }
-
-        const response = new CreateQueueResponseDecoder().decodeFrom(context.message, String(message.message_id))
-        if (response.status === "error") {
-          return rej(response.error)
-        }
-
-        return res(new AmqpQueue(response.body))
-      })
-
-      const message = new LinkMessageBuilder()
-        .sendTo(`/${AmqpEndpoints.Queues}/${encodeURIComponent(queueName)}`)
-        .setReplyTo(ME)
-        .setAmqpMethod(AmqpMethods.PUT)
-        .setBody(buildDeclareQueueBody(options))
-        .build()
-      this.senderLink.send(message)
-    })
+    const message = new LinkMessageBuilder()
+      .sendTo(`/${AmqpEndpoints.Queues}/${encodeURIComponent(queueName)}`)
+      .setReplyTo(ME)
+      .setAmqpMethod(AmqpMethods.PUT)
+      .setBody(buildDeclareQueueBody(options))
+      .build()
+    const responseMessage = await this.sendAndAwait(message)
+    const response = new CreateQueueResponseDecoder().decodeFrom(responseMessage, String(message.message_id))
+    if (response.status === "error") throw response.error
+    return new AmqpQueue(response.body)
   }
 
   async deleteQueue(queueName: string): Promise<boolean> {
-    return new Promise((res, rej) => {
-      this.receiverLink.once(ReceiverEvents.message, (context: EventContext) => {
-        if (!context.message) {
-          return rej(new Error("Receiver has not received any message"))
-        }
-
-        const response = new DeleteQueueResponseDecoder().decodeFrom(context.message, String(message.message_id))
-        if (response.status === "error") {
-          return rej(response.error)
-        }
-
-        return res(true)
-      })
-
-      const message = new LinkMessageBuilder()
-        .sendTo(`/${AmqpEndpoints.Queues}/${encodeURIComponent(queueName)}`)
-        .setReplyTo(ME)
-        .setAmqpMethod(AmqpMethods.DELETE)
-        .build()
-      this.senderLink.send(message)
-    })
+    const message = new LinkMessageBuilder()
+      .sendTo(`/${AmqpEndpoints.Queues}/${encodeURIComponent(queueName)}`)
+      .setReplyTo(ME)
+      .setAmqpMethod(AmqpMethods.DELETE)
+      .build()
+    const responseMessage = await this.sendAndAwait(message)
+    const response = new DeleteQueueResponseDecoder().decodeFrom(responseMessage, String(message.message_id))
+    if (response.status === "error") throw response.error
+    return true
   }
 
   async getQueueInfo(queueName: string): Promise<Queue> {
-    return new Promise((res, rej) => {
-      this.receiverLink.once(ReceiverEvents.message, (context: EventContext) => {
-        if (!context.message) {
-          return rej(new Error("Receiver has not received any message"))
-        }
-
-        const response = new GetQueueInfoResponseDecoder().decodeFrom(context.message, String(message.message_id))
-        if (response.status === "error") {
-          return rej(response.error)
-        }
-
-        return res(new AmqpQueue(response.body))
-      })
-
-      const message = new LinkMessageBuilder()
-        .sendTo(`/${AmqpEndpoints.Queues}/${encodeURIComponent(queueName)}`)
-        .setReplyTo(ME)
-        .setAmqpMethod(AmqpMethods.GET)
-        .build()
-      this.senderLink.send(message)
-    })
+    const message = new LinkMessageBuilder()
+      .sendTo(`/${AmqpEndpoints.Queues}/${encodeURIComponent(queueName)}`)
+      .setReplyTo(ME)
+      .setAmqpMethod(AmqpMethods.GET)
+      .build()
+    const responseMessage = await this.sendAndAwait(message)
+    const response = new GetQueueInfoResponseDecoder().decodeFrom(responseMessage, String(message.message_id))
+    if (response.status === "error") throw response.error
+    return new AmqpQueue(response.body)
   }
 
   async declareExchange(exchangeName: string, options: Partial<ExchangeOptions> = {}): Promise<Exchange> {
@@ -156,58 +147,33 @@ export class AmqpManagement implements Management {
       durable: options.durable ?? true,
       name: exchangeName,
     }
-    return new Promise((res, rej) => {
-      this.receiverLink.once(ReceiverEvents.message, (context: EventContext) => {
-        if (!context.message) {
-          return rej(new Error("Receiver has not received any message"))
-        }
-
-        const response = new CreateExchangeResponseDecoder().decodeFrom(context.message, String(message.message_id))
-        if (response.status === "error") {
-          return rej(response.error)
-        }
-
-        return res(new AmqpExchange(exchangeInfo))
+    const message = new LinkMessageBuilder()
+      .sendTo(`/${AmqpEndpoints.Exchanges}/${encodeURIComponent(exchangeName)}`)
+      .setReplyTo(ME)
+      .setAmqpMethod(AmqpMethods.PUT)
+      .setBody({
+        type: options.type ?? "direct",
+        durable: options.durable ?? true,
+        auto_delete: options.auto_delete ?? false,
+        arguments: options.arguments ?? {},
       })
-
-      const message = new LinkMessageBuilder()
-        .sendTo(`/${AmqpEndpoints.Exchanges}/${encodeURIComponent(exchangeName)}`)
-        .setReplyTo(ME)
-        .setAmqpMethod(AmqpMethods.PUT)
-        .setBody({
-          type: options.type ?? "direct",
-          durable: options.durable ?? true,
-          auto_delete: options.auto_delete ?? false,
-          arguments: options.arguments ?? {},
-        })
-        .build()
-
-      this.senderLink.send(message)
-    })
+      .build()
+    const responseMessage = await this.sendAndAwait(message)
+    const response = new CreateExchangeResponseDecoder().decodeFrom(responseMessage, String(message.message_id))
+    if (response.status === "error") throw response.error
+    return new AmqpExchange(exchangeInfo)
   }
 
   async deleteExchange(exchangeName: string): Promise<boolean> {
-    return new Promise((res, rej) => {
-      this.receiverLink.once(ReceiverEvents.message, (context: EventContext) => {
-        if (!context.message) {
-          return rej(new Error("Receiver has not received any message"))
-        }
-
-        const response = new DeleteExchangeResponseDecoder().decodeFrom(context.message, String(message.message_id))
-        if (response.status === "error") {
-          return rej(response.error)
-        }
-
-        return res(true)
-      })
-
-      const message = new LinkMessageBuilder()
-        .sendTo(`/${AmqpEndpoints.Exchanges}/${encodeURIComponent(exchangeName)}`)
-        .setReplyTo(ME)
-        .setAmqpMethod(AmqpMethods.DELETE)
-        .build()
-      this.senderLink.send(message)
-    })
+    const message = new LinkMessageBuilder()
+      .sendTo(`/${AmqpEndpoints.Exchanges}/${encodeURIComponent(exchangeName)}`)
+      .setReplyTo(ME)
+      .setAmqpMethod(AmqpMethods.DELETE)
+      .build()
+    const responseMessage = await this.sendAndAwait(message)
+    const response = new DeleteExchangeResponseDecoder().decodeFrom(responseMessage, String(message.message_id))
+    if (response.status === "error") throw response.error
+    return true
   }
 
   async bind(key: string, options: BindingOptions): Promise<Binding> {
@@ -217,84 +183,48 @@ export class AmqpManagement implements Management {
       destination: options.destination.getInfo.name,
       arguments: options.arguments ?? {},
     }
-    return new Promise((res, rej) => {
-      this.receiverLink.once(ReceiverEvents.message, (context: EventContext) => {
-        if (!context.message) {
-          return rej(new Error("Receiver has not received any message"))
-        }
-
-        const response = new CreateBindingResponseDecoder().decodeFrom(context.message, String(message.message_id))
-        if (response.status === "error") {
-          return rej(response.error)
-        }
-
-        return res(new AmqpBinding(bindingInfo))
+    const message = new LinkMessageBuilder()
+      .sendTo(`/${AmqpEndpoints.Bindings}`)
+      .setReplyTo(ME)
+      .setAmqpMethod(AmqpMethods.POST)
+      .setBody({
+        source: options.source.getInfo.name,
+        binding_key: key,
+        arguments: options.arguments ?? {},
+        ...buildBindingDestinationFrom(options.destination),
       })
-
-      const message = new LinkMessageBuilder()
-        .sendTo(`/${AmqpEndpoints.Bindings}`)
-        .setReplyTo(ME)
-        .setAmqpMethod(AmqpMethods.POST)
-        .setBody({
-          source: options.source.getInfo.name,
-          binding_key: key,
-          arguments: options.arguments ?? {},
-          ...buildBindingDestinationFrom(options.destination),
-        })
-        .build()
-      this.senderLink.send(message)
-    })
+      .build()
+    const responseMessage = await this.sendAndAwait(message)
+    const response = new CreateBindingResponseDecoder().decodeFrom(responseMessage, String(message.message_id))
+    if (response.status === "error") throw response.error
+    return new AmqpBinding(bindingInfo)
   }
 
   async unbind(key: string, options: BindingOptions): Promise<boolean> {
-    return new Promise((res, rej) => {
-      this.receiverLink.once(ReceiverEvents.message, (context: EventContext) => {
-        if (!context.message) {
-          return rej(new Error("Receiver has not received any message"))
-        }
-
-        const response = new DeleteBindingResponseDecoder().decodeFrom(context.message, String(message.message_id))
-        if (response.status === "error") {
-          return rej(response.error)
-        }
-
-        return res(true)
-      })
-
-      const message = new LinkMessageBuilder()
-        .sendTo(
-          `/${AmqpEndpoints.Bindings}/${buildUnbindEndpointFrom({ source: options.source, destination: options.destination, key })}`
-        )
-        .setReplyTo(ME)
-        .setAmqpMethod(AmqpMethods.DELETE)
-        .build()
-      this.senderLink.send(message)
-    })
+    const message = new LinkMessageBuilder()
+      .sendTo(
+        `/${AmqpEndpoints.Bindings}/${buildUnbindEndpointFrom({ source: options.source, destination: options.destination, key })}`
+      )
+      .setReplyTo(ME)
+      .setAmqpMethod(AmqpMethods.DELETE)
+      .build()
+    const responseMessage = await this.sendAndAwait(message)
+    const response = new DeleteBindingResponseDecoder().decodeFrom(responseMessage, String(message.message_id))
+    if (response.status === "error") throw response.error
+    return true
   }
 
   async refreshToken(token: string): Promise<boolean> {
-    return new Promise((res, rej) => {
-      this.receiverLink.once(ReceiverEvents.message, (context: EventContext) => {
-        if (!context.message) {
-          return rej(new Error("Receiver has not received any message"))
-        }
-
-        const response = new RefreshTokensResponseDecoder().decodeFrom(context.message, String(message.message_id))
-        if (response.status === "error") {
-          return rej(response.error)
-        }
-
-        return res(true)
-      })
-
-      const message = new LinkMessageBuilder()
-        .sendTo(`/${AmqpEndpoints.AuthTokens}`)
-        .setReplyTo(ME)
-        .setAmqpMethod(AmqpMethods.PUT)
-        .setBody(Buffer.from(token, "ascii"))
-        .build()
-      this.senderLink.send(message)
-    })
+    const message = new LinkMessageBuilder()
+      .sendTo(`/${AmqpEndpoints.AuthTokens}`)
+      .setReplyTo(ME)
+      .setAmqpMethod(AmqpMethods.PUT)
+      .setBody(Buffer.from(token, "ascii"))
+      .build()
+    const responseMessage = await this.sendAndAwait(message)
+    const response = new RefreshTokensResponseDecoder().decodeFrom(responseMessage, String(message.message_id))
+    if (response.status === "error") throw response.error
+    return true
   }
 }
 

--- a/test/unit/rhea/management.test.ts
+++ b/test/unit/rhea/management.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect, vi } from "vitest"
+import { EventEmitter } from "events"
+import { Connection as RheaConnection, ReceiverEvents, Receiver, Sender } from "rhea"
+import { AmqpManagement } from "../../../src/management.js"
+
+function createMocks() {
+  const receiverEmitter = new EventEmitter()
+  const sentMessages: Array<{ message_id: string }> = []
+
+  const mockSender = {
+    send: vi.fn((msg) => {
+      sentMessages.push(msg)
+      return { id: sentMessages.length }
+    }),
+    close: vi.fn(),
+  }
+  const mockReceiver = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => receiverEmitter.on(event, handler)),
+    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => receiverEmitter.once(event, handler)),
+    close: vi.fn(),
+    is_open: vi.fn(() => false),
+  }
+  const mockConn = { is_closed: vi.fn(() => false) }
+
+  return { receiverEmitter, sentMessages, mockSender, mockReceiver, mockConn }
+}
+
+describe("AmqpManagement: concurrent request routing", () => {
+  test("single declareQueue resolves when its response arrives", async () => {
+    const { receiverEmitter, sentMessages, mockSender, mockReceiver, mockConn } = createMocks()
+    const management = new AmqpManagement(
+      mockConn as unknown as RheaConnection,
+      mockSender as unknown as Sender,
+      mockReceiver as unknown as Receiver
+    )
+
+    const declareQueuePromise = management.declareQueue("test-queue")
+    await new Promise((r) => setImmediate(r))
+
+    const msgId = sentMessages[0].message_id
+    receiverEmitter.emit(ReceiverEvents.message, {
+      message: {
+        subject: "201",
+        correlation_id: msgId,
+        body: { name: "test-queue", durable: 1, auto_delete: 0, exclusive: 0, type: "classic", arguments: {} },
+      },
+    })
+
+    const queue = await declareQueuePromise
+    expect(queue).toBeDefined()
+  })
+
+  test("concurrent refreshToken and declareQueue: each response routed to the correct handler", async () => {
+    const { receiverEmitter, sentMessages, mockSender, mockReceiver, mockConn } = createMocks()
+    const management = new AmqpManagement(
+      mockConn as unknown as RheaConnection,
+      mockSender as unknown as Sender,
+      mockReceiver as unknown as Receiver
+    )
+
+    const tokenRefreshPromise = management.refreshToken("new-oauth-token")
+    const declareQueuePromise = management.declareQueue("my-queue")
+
+    await new Promise((r) => setImmediate(r))
+
+    expect(sentMessages).toHaveLength(2)
+    const refreshTokenMsgId = sentMessages[0].message_id
+    const declareQueueMsgId = sentMessages[1].message_id
+
+    // Deliver declareQueue response first (wrong order — the race)
+    receiverEmitter.emit(ReceiverEvents.message, {
+      message: {
+        subject: "201",
+        correlation_id: declareQueueMsgId,
+        body: { name: "my-queue", durable: 1, auto_delete: 0, exclusive: 0, type: "classic", arguments: {} },
+      },
+    })
+
+    // declareQueue should resolve correctly
+    const queue = await declareQueuePromise
+    expect(queue).toBeDefined()
+
+    // refreshToken must NOT have been rejected by the declareQueue response
+    let tokenRejected = false
+    tokenRefreshPromise.catch(() => {
+      tokenRejected = true
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    expect(tokenRejected).toBe(false)
+
+    // Deliver the refreshToken response — it must still resolve
+    receiverEmitter.emit(ReceiverEvents.message, {
+      message: {
+        subject: "200",
+        correlation_id: refreshTokenMsgId,
+        body: null,
+      },
+    })
+
+    const tokenResult = await tokenRefreshPromise
+    expect(tokenResult).toBe(true)
+  })
+})


### PR DESCRIPTION
Because all management operations share a single receiver link, the use of once() to handle responses fromt he broker meant that, in the case of multiple management requests, responses would be registered to the first requester, even if the response was to a different request. When the correlation IDs don't match, the decoder returns an error and the promise rejects, and the correct handler is unable to resolve, causing a promise leak.

This PR uses a routing map with a persistent listener to eliminate the race condition and promise leak.

[ai-assisted=yes]