### PR TITLE
Implement Direct Reply-To

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   rabbitmq-js-client:
-    image: rabbitmq:4.2.0-beta.3-management
+    image: rabbitmq:4.2-management
     container_name: rabbitmq-js-client
     restart: unless-stopped
     hostname: "rabbitmq"

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -5,6 +5,7 @@ import { AmqpPublisher, Publisher } from "./publisher.js"
 import { DestinationOptions } from "./message.js"
 import { AmqpConsumer, Consumer, CreateConsumerParams } from "./consumer.js"
 import { openRheaConnection } from "./rhea_wrapper.js"
+import { isBrokerVersionAtLeast } from "./utils.js"
 
 export interface Connection {
   close(): Promise<boolean>
@@ -51,11 +52,13 @@ export class AmqpConnection implements Connection {
       envParams.oauth ? () => bridge.getPassword() : undefined
     )
     const topologyManagement = await AmqpManagement.create(rheaConnection)
+    const isDirectReplyToSupported = isBrokerVersionAtLeast(rheaConnection.properties, 4, 2)
     return new AmqpConnection(
       rheaConnection,
       topologyManagement,
       envParams.oauth ? envParams.oauth.token : envParams.password,
-      bridge
+      bridge,
+      isDirectReplyToSupported
     )
   }
 
@@ -63,7 +66,8 @@ export class AmqpConnection implements Connection {
     private readonly connection: RheaConnection,
     private readonly topologyManagement: Management,
     private password: string,
-    bridge: PasswordBridge
+    bridge: PasswordBridge,
+    private readonly _isDirectReplyToSupported: boolean = false
   ) {
     bridge.register(() => this.getPassword())
   }
@@ -88,6 +92,9 @@ export class AmqpConnection implements Connection {
   }
 
   async createConsumer(params: CreateConsumerParams): Promise<Consumer> {
+    if ("directReplyTo" in params && params.directReplyTo && !this._isDirectReplyToSupported) {
+      throw new Error("Direct reply-to is not supported by this broker. RabbitMQ 4.2 or later is required.")
+    }
     const consumer = await AmqpConsumer.createFrom(this.connection, this._consumers, params)
     this._consumers.set(consumer.id, consumer)
     return consumer

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -41,10 +41,17 @@ export type StreamOptions = {
 
 export type SourceOptions = { stream: StreamOptions } | { queue: QueueOptions }
 
-export type CreateConsumerParams = SourceOptions & {
+export type QueueConsumerParams = SourceOptions & {
   preSettled?: boolean
   messageHandler: ConsumerMessageHandler
 }
+
+export type DirectReplyToConsumerParams = {
+  directReplyTo: true
+  messageHandler: ConsumerMessageHandler
+}
+
+export type CreateConsumerParams = QueueConsumerParams | DirectReplyToConsumerParams
 
 const getConsumerReceiverLinkConfigurationFrom = (
   address: string,
@@ -68,10 +75,26 @@ const getConsumerReceiverLinkConfigurationFrom = (
   },
 })
 
+const getDirectReplyToReceiverLinkConfiguration = (consumerId: string): ReceiverOptions => ({
+  snd_settle_mode: 1,
+  rcv_settle_mode: 0,
+  autoaccept: true,
+  autosettle: true,
+  name: consumerId,
+  source: {
+    address: null as unknown as string,
+    dynamic: true,
+    expiry_policy: "link-detach",
+    timeout: 0,
+    capabilities: ["rabbitmq:volatile-queue"],
+  },
+})
+
 export interface Consumer {
   start(): void
   close(): void
   get id(): string
+  get replyTo(): string | undefined
 }
 
 export class AmqpConsumer implements Consumer {
@@ -79,11 +102,17 @@ export class AmqpConsumer implements Consumer {
 
   static async createFrom(connection: Connection, consumersList: Map<string, Consumer>, params: CreateConsumerParams) {
     const id = generate_uuid()
-    const address = createConsumerAddressFrom(params)
-    const filter = createConsumerFilterFrom(params)
-    if (!address) throw new Error("Consumer must have an address")
 
-    const preSettled = params.preSettled ?? false
+    if ("directReplyTo" in params && params.directReplyTo) {
+      const receiverLink = await AmqpConsumer.openDirectReplyToReceiver(connection, id)
+      return new AmqpConsumer(id, connection, consumersList, receiverLink, params)
+    }
+
+    const sourceParams = params as QueueConsumerParams
+    const address = createConsumerAddressFrom(sourceParams)
+    const filter = createConsumerFilterFrom(sourceParams)
+    if (!address) throw new Error("Consumer must have an address")
+    const preSettled = sourceParams.preSettled ?? false
     const receiverLink = await AmqpConsumer.openReceiver(connection, address, id, preSettled, filter)
     return new AmqpConsumer(id, connection, consumersList, receiverLink, params)
   }
@@ -104,6 +133,16 @@ export class AmqpConsumer implements Consumer {
     )
   }
 
+  private static async openDirectReplyToReceiver(connection: Connection, consumerId: string): Promise<Receiver> {
+    return openLink<Receiver>(
+      connection,
+      ReceiverEvents.receiverOpen,
+      ReceiverEvents.receiverError,
+      connection.open_receiver.bind(connection),
+      getDirectReplyToReceiverLinkConfiguration(consumerId)
+    )
+  }
+
   constructor(
     private readonly _id: string,
     private readonly connection: Connection,
@@ -118,10 +157,16 @@ export class AmqpConsumer implements Consumer {
     return this._id
   }
 
+  get replyTo(): string | undefined {
+    return this.receiverLink.source?.address
+  }
+
   start() {
     this.receiverLink.on(ReceiverEvents.message, (context: EventContext) => {
       if (context.message && context.delivery) {
-        const deliveryContext = this.params.preSettled
+        const isPreSettled =
+          "directReplyTo" in this.params ? true : ((this.params as QueueConsumerParams).preSettled ?? false)
+        const deliveryContext = isPreSettled
           ? AmqpConsumer.PRE_SETTLED_DELIVERY_CONTEXT
           : new AmqpDeliveryContext(context.delivery, this.receiverLink)
         this.params.messageHandler(deliveryContext, context.message)
@@ -136,7 +181,7 @@ export class AmqpConsumer implements Consumer {
   }
 }
 
-function createConsumerFilterFrom(params: CreateConsumerParams): SourceFilter | undefined {
+function createConsumerFilterFrom(params: QueueConsumerParams): SourceFilter | undefined {
   if ("queue" in params) {
     return undefined
   }

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,7 +1,7 @@
 import { Dictionary, generate_uuid, MessageAnnotations, MessageProperties, Message as RheaMessage } from "rhea"
 import { AmqpEndpoints } from "./link_message_builder.js"
 import { inspect } from "util"
-import { CreateConsumerParams } from "./consumer.js"
+import { QueueConsumerParams } from "./consumer.js"
 
 export type ExchangeOptions = {
   name: string
@@ -57,7 +57,7 @@ export function createPublisherAddressFrom(options?: DestinationOptions): string
   throw new Error(`Unknown publisher options -- ${inspect(options)}`)
 }
 
-export function createConsumerAddressFrom(params: CreateConsumerParams): string | undefined {
+export function createConsumerAddressFrom(params: QueueConsumerParams): string | undefined {
   if ("queue" in params) return `/${AmqpEndpoints.Queues}/${params.queue.name}`
   if ("stream" in params) return `/${AmqpEndpoints.Queues}/${params.stream.name}`
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,6 +49,17 @@ export function isError(message: Message): boolean {
   )
 }
 
+export function isBrokerVersionAtLeast(
+  properties: { [x: string]: unknown } | undefined,
+  major: number,
+  minor: number
+): boolean {
+  const version = properties?.version
+  if (typeof version !== "string") return false
+  const [maj, min] = version.split(".").map(Number)
+  return maj > major || (maj === major && min >= minor)
+}
+
 export function queueTypeFromString(queueType: string): QueueType {
   switch (queueType) {
     case "classic":

--- a/test/e2e/direct_reply_to.test.ts
+++ b/test/e2e/direct_reply_to.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, beforeEach, afterEach, expect } from "vitest"
+import { createEnvironment, Environment } from "../../src/environment.js"
+import { Connection } from "../../src/connection.js"
+import { eventually, host, password, port, username, cleanRabbit } from "../support/util.js"
+import { Message } from "rhea"
+
+describe("Direct Reply-To", () => {
+  let environment: Environment
+  let connection: Connection
+  const requestQueueName = "test-direct-reply-to-request"
+
+  beforeEach(async () => {
+    environment = createEnvironment({ host, port, username, password })
+    connection = await environment.createConnection()
+    await connection.management().declareQueue(requestQueueName)
+  })
+
+  afterEach(async () => {
+    try {
+      await cleanRabbit({ match: /test-direct-reply-to/ })
+      await connection.close()
+      await environment.close()
+    } catch (error) {
+      console.error(error)
+    }
+  })
+
+  test("direct reply-to consumer gets a replyTo address from the broker", async () => {
+    const consumer = await connection.createConsumer({
+      directReplyTo: true,
+      messageHandler: () => {},
+    })
+
+    consumer.start()
+
+    expect(consumer.replyTo).toContain("amq.rabbitmq.reply-to")
+  })
+
+  test("direct reply-to enables ping-pong without a reply queue", async () => {
+    let receivedReply: Message | undefined
+
+    const requesterConsumer = await connection.createConsumer({
+      directReplyTo: true,
+      messageHandler: (_ctx, message) => {
+        receivedReply = message
+      },
+    })
+    requesterConsumer.start()
+
+    const responderPublisher = await connection.createPublisher()
+    const responderConsumer = await connection.createConsumer({
+      queue: { name: requestQueueName },
+      messageHandler: (ctx, message) => {
+        ctx.accept()
+        if (message.reply_to) {
+          responderPublisher.publish({ body: "pong", to: message.reply_to })
+        }
+      },
+    })
+    responderConsumer.start()
+
+    const requesterPublisher = await connection.createPublisher({ queue: { name: requestQueueName } })
+
+    await requesterPublisher.publish({ body: "ping", reply_to: requesterConsumer.replyTo })
+
+    await eventually(() => {
+      expect(receivedReply).toBeDefined()
+      expect(receivedReply!.body).toBe("pong")
+    })
+  })
+})


### PR DESCRIPTION
Introduces a directReplyTo consumer type that opens a dynamic receiver link on the broker's Direct Reply-To pseudo-queue, enabling request/reply patterns without declaring a dedicated reply queue. The feature requires RabbitMQ 4.2 or later; attempting to use it on an older broker throws an informative error. The Consumer interface now exposes a replyTo address property so publishers can address replies back to the consumer.

Closes #80 