### PR TITLE
Update README to remove API change warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # RabbitMQ AMQP 1.0 JavaScript Client
 
 This library is meant to be used with RabbitMQ `4.x`. </br>
-Suitable for testing in pre-production environments. The public API(s) could change.
 
 [![Build Status](https://github.com/coders51/rabbitmq-amqp-js-client/actions/workflows/main.yml/badge.svg)](https://github.com/coders51/rabbitmq-amqp-js-client/actions)
 


### PR DESCRIPTION
Remove note about public API changes. Since we are going to release 1.0